### PR TITLE
Bug fixed; minor code correction added

### DIFF
--- a/blog/mainapp/views.py
+++ b/blog/mainapp/views.py
@@ -83,7 +83,7 @@ class PostDetailView(LoginRequiredMixin, DetailView):
         self.object = self.get_object()
         context = super().get_context_data(**kwargs)
 
-        post = Post.objects.filter(id=self.kwargs['pk'])[0]
+        post = Post.objects.filter(id=self.kwargs['pk']).first()
         comments = post.comment_set.all()
 
         context['post'] = post
@@ -100,7 +100,7 @@ class PostDetailView(LoginRequiredMixin, DetailView):
 
             form = CommentForm()
             context['form'] = form
-            return HttpResponseRedirect(reverse('mainapp:post-detail', args=str(post.pk)))
+            return HttpResponseRedirect(reverse('mainapp:post-detail', kwargs={'pk': post.pk}))
         return self.render_to_response(context=context)
 
 


### PR DESCRIPTION
Баг починен.

**Причина**: 
'PostDetailView:post():103', т.е. обращение к id поста через `args=str(post.pk)` -> там должно быть что-то, что можно проитерировать, но args в обертке str итерируется буквально, т.е. двузначное число воспринимается как два str, а не один int. 

**Решение**:
поместить все из args в **kwargs**, принимающий словарь: `kwargs={'pk': post.pk}`, где значение - int, воспринимаемый буквально, но условие итерируемости все равно соблюдается, т.к. dict. 
Альтернативно можно было бы сделать `args=(post.pk,)`, т.е. поместить все в tuple, но никогда не видел такой реализации, выглядит малость чужеродно. 

Бонус: 
Post.objects.filter(id=self.kwargs['pk']).**first()** вместо Post.objects.filter(id=self.kwargs['pk'])**[0]**, чтобы было красиво и при значении `None` не падало.